### PR TITLE
fix: Sin::new should be public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ unsafe impl<T> Send for Sin<T> {}
 impl<T: Clone> Copy for Sin<T>  {}
 
 impl<T> Sin<T> {
-    fn new(data: T) -> Self {
+    pub fn new(data: T) -> Self {
         let ptr = Box::into_raw(Box::new(Sinner {
             data,
             ref_count: 1,


### PR DESCRIPTION
Tried to use this library in production, couldn't create Sin.

![image](https://user-images.githubusercontent.com/38285861/146543257-8cb9a767-2984-41ef-8e01-af9c895ebca8.png)

Changed the visibility to public so that I can commit unspeakable acts outside of the scope of the library.

(this PR allows the first example to compile and run)