### PR TITLE
Remove unnecessary `return` in `Sin::from`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl<T> Sin<T> {
 
 impl<T> From<T> for Sin<T> {
     fn from(v: T) -> Self {
-        return Self::new(v);
+        Self::new(v)
     }
 }
 


### PR DESCRIPTION
Because that is definitely тнє Ø₦ⱠɎ ₮̴̗̯̗͈͈̹́̂̇̚͝Ⱨ̵̢̳͍̖̻̮͙̥͇̀͒̔̋̃͆̍̔̄̚͜ł̶̱̣͋̂̍̽̓̐̑̈́͘₦̵̧̡͖̭̼̄₲̶̮̭̱̟̘̠̉̓̀̈́͌̌̂̕ͅ ̴̨̦͍̹̘͂͌₩̵̣͌̓͝Ɽ̸̢̡̙̭̞̅͂̀̃̂͗Ø̸͇̫͇̞͕̬͕̱̦̓̋̽̇̅̕₦̶̛͓̟̮̳̤̎̍͋₲̷̡̱̟̬̫̒͗̾̎͂͘̕ ̸̧͉͎̭̖̺̒̌̂̒͝₩̸͉̠̲̣̳͘ł̸̧̞̠̭̬͕̯͈̒̈́̆̕₮̴̨̣̼̙͂͛͊̉̈́Ⱨ̷͙̿̒̈̐͠ͅͅ ̶̡̡̜͎̞̳̬̝͉̤̈́̀̆̃̿̾̒̿́₮̷̛̲̖̲̫̗̺̗̜̽̉͊̀̈́̆̕͜Ⱨ̴̡͕̩͓̠̫͗ł̵̨̫̘̲͈̫̼͂̋̀̀̔₴̴̢̧͔̘͓̦̰͇̓͌͊̎̓̾͑